### PR TITLE
Add support for custom interfaces

### DIFF
--- a/grapple/actions.py
+++ b/grapple/actions.py
@@ -212,7 +212,7 @@ def build_node_type(
             "lazy": True,
             "name": type_name,
             "base_type": base_type,
-            "interface": interface,
+            "interface": cls.get_interface(interface) if hasattr(cls, 'get_interface') else interface,
         },
     }
 
@@ -235,7 +235,7 @@ def load_type_fields():
                 # Recreate the graphene type with the fields set
                 class Meta:
                     model = cls
-                    interfaces = (interface,) if interface is not None else tuple()
+                    interfaces = interface if type(interface) is tuple else (interface, ) if interface is not None else tuple()
 
                 type_meta = {"Meta": Meta, "id": graphene.ID(), "name": type_name}
                 exclude_fields = get_fields_and_properties(cls)


### PR DESCRIPTION
Allow custom resolvers within a wagtail-grapple setup, by injecting an interface.

```
class Event(HeadlessPreviewMixin, Page):

    @classmethod
    def get_interface(self, interface):
        class EventInterface(graphene.Interface):
            saved = graphene.Boolean(argument_1=graphene.Boolean(required=True), required=True)

            def resolve_saved(self, info, **kwargs):
                print("resolve_saved", info.context.user)
                return False

        return (interface, EventInterface, )
```